### PR TITLE
add the ajv dependency to fix the docker build

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,8 +5,8 @@ services:
       context: .
     container_name: iqbit
     restart: unless-stopped
-    ports:
-      - 8081:8081
+    expose:
+      - 8081
     environment:
       - QBIT_HOST=http://localhost:8080
       - STANDALONE_SERVER_PORT=8081

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@types/node": "^16.7.13",
     "@types/react": "18.0.15",
     "@types/react-dom": "18.0.6",
+    "ajv": "^8.16.0",
     "axios": "^1.6.5",
     "cors": "^2.8.5",
     "eslint": "^8.11.0",


### PR DESCRIPTION
Just ran into a slight npm dependency issue when trying to build the docker image from source. Adding ajv latest seemed to do the trick. 