### PR TITLE
Pause action button to call "pause" instead of "stop"

### DIFF
--- a/src/utils/TorrClient.ts
+++ b/src/utils/TorrClient.ts
@@ -91,7 +91,7 @@ export const TorrClient = {
   },
 
   pause: async (hash = "") => {
-    return await APICall.post("torrents/stop", `hashes=${hash}`);
+    return await APICall.post("torrents/pause", `hashes=${hash}`);
   },
 
   pauseAll: async () => {


### PR DESCRIPTION
Pause button calls `/api/v2/torrents/stop` which results in a 404 error.
This fix will prevent the error and make the pause button work as expected