### PR TITLE
issue-127: Fix: Flash when list is empty + Filter alignment (Issue #127)

### DIFF
--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -383,7 +383,7 @@ const Home = () => {
             </LightMode>
           </IosBottomSheet>
 
-          <Box bgColor={bgColor} rounded={"lg"} mb={5} mt={isLarge ? 10 : 0}>
+          <Box bgColor={bgColor} rounded={"lg"} mb={5} mt={10}>
             <FilterHeading
               indicator={filterIndicator}
               disclosure={filterDisclosure}
@@ -428,17 +428,15 @@ const Home = () => {
           </Box>
 
           <Flex flexDirection={"column"} gap={5}>
-            {!Torrents?.length &&
-              isFetching &&
-              Array.from(Array(10).keys()).map((key) => (
-                <TorrentBox
-                  key={key}
-                  torrentData={randomTorrent}
-                  categories={[]}
-                  hash={""}
-                  loading
-                />
-              ))}
+            {!Torrents?.length && isLoading && filterIndicator === 0 && Array.from(Array(10).keys()).map((key) => (
+              <TorrentBox
+                key={key}
+                torrentData={randomTorrent}
+                categories={[]}
+                hash={""}
+                loading
+              />
+            ))}
 
             {Torrents.length === 0 && filterIndicator > 0 && (
               <Flex alignItems={"center"} flexDirection={"column"} gap={4}>


### PR DESCRIPTION
<img width="407" height="282" alt="filter-overlap-1" src="https://github.com/user-attachments/assets/d8ee0b24-52a2-4b66-b8b9-7b59cf070288" />
<img width="399" height="144" alt="filter-overlap-2" src="https://github.com/user-attachments/assets/c280c86c-a7e0-45ab-b928-2f913c266ad2" />

https://github.com/user-attachments/assets/7f23073e-ee8b-4db0-8717-192ac41ff5ad

