### PR TITLE
fix: resolve infinite loading loop on qBittorrent session expiration

### DIFF
--- a/public/yts-mirrors.json
+++ b/public/yts-mirrors.json
@@ -1,8 +1,10 @@
 {
     "mirrors": [
+        "https://yts.mx/api/v2/",
         "https://yts.bz/api/v2/",
         "https://yts.lt/api/v2/",
         "https://yts.am/api/v2/",
         "https://yts.ag/api/v2/"
     ]
 }
+

--- a/public/yts-mirrors.json
+++ b/public/yts-mirrors.json
@@ -1,10 +1,10 @@
 {
     "mirrors": [
-        "https://yts.mx/api/v2/",
+        "https://movies-api.accel.li/api/v2/",     // ←New Official (most reliablea)
         "https://yts.bz/api/v2/",
+        "https://yts.gg/api/v2/",
         "https://yts.lt/api/v2/",
         "https://yts.am/api/v2/",
         "https://yts.ag/api/v2/"
     ]
 }
-

--- a/public/yts-mirrors.json
+++ b/public/yts-mirrors.json
@@ -1,6 +1,6 @@
 {
     "mirrors": [
-        "https://movies-api.accel.li/api/v2/",     // ←New Official (most reliablea)
+        "https://movies-api.accel.li/api/v2/",
         "https://yts.bz/api/v2/",
         "https://yts.gg/api/v2/",
         "https://yts.lt/api/v2/",

--- a/src/utils/TorrClient.ts
+++ b/src/utils/TorrClient.ts
@@ -21,6 +21,48 @@ const APICall = axios.create({
   withCredentials: true,
 });
 
+APICall.interceptors.response.use(
+  (response) => response,
+  async (error) => {
+    const originalRequest = error.config;
+
+    if (
+      error.response &&
+      (error.response.status === 401 || error.response.status === 403) &&
+      !originalRequest._retry &&
+      originalRequest.url !== "auth/login"
+    ) {
+      originalRequest._retry = true;
+
+      try {
+        const credsStr = window.localStorage.getItem("iqbit_creds");
+        if (credsStr) {
+          const localCreds = JSON.parse(credsStr);
+          if (localCreds && localCreds.username && localCreds.password) {
+            const loginRes = await TorrClient.login({
+              username: localCreds.username,
+              password: localCreds.password,
+            });
+
+            if (loginRes.data === "Ok.") {
+              return APICall(originalRequest);
+            }
+          }
+        }
+      } catch (e) {
+        console.error("Auto re-login failed", e);
+      }
+
+      // If re-login fails or we don't have creds, clear creds and reload
+      window.localStorage.removeItem("iqbit_creds");
+      window.location.reload();
+      return Promise.reject(error);
+    }
+
+    return Promise.reject(error);
+  }
+);
+
 export const TorrClient = {
   getVersion: async () => {
     return await APICall.get("/app/version");


### PR DESCRIPTION
When the qBittorrent session expires (usually after ~2 hours), the UI ends up in an endless loading loop because API calls return 401/403 errors and the application keeps retrying or getting stuck without successfully logging out or re-authenticating.